### PR TITLE
fix inconsistent between align and edit_distance

### DIFF
--- a/extensions/kaldi_align.cpp
+++ b/extensions/kaldi_align.cpp
@@ -94,11 +94,11 @@ int LevenshteinAlignment(const std::vector<int> &a,
       int del = e[m-1][n] + 1;  // assumes a == ref, b == hyp.
       int ins = e[m][n-1] + 1;
       // choose sub_or_ok if all else equal.
-      if (sub_or_ok <= std::min(del, ins)) {
+      if (sub_or_ok < std::min(del, ins)) {
         last_m = m-1;
         last_n = n-1;
       } else {
-        if (del <= ins) {  // choose del over ins if equal.
+        if (del < ins) {  // choose del over ins if equal.
           last_m = m-1;
           last_n = n;
         } else {

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -7,7 +7,31 @@ def test_align():
     a = ['a', 'b', 'c']
     b = ['a', 's', 'x', 'c']
     ali = align(a, b, EPS)
-    assert ali == [('a', 'a'), (EPS, 's'), ('b', 'x'), ('c', 'c')]
+    assert ali == [('a', 'a'), ('b', 's'), (EPS, 'x'), ('c', 'c')]
+    dist = edit_distance(a, b)
+    assert dist == { 'ins': 1, 'del': 0, 'sub': 1, 'total': 2}
+
+    a = ['a', 'b']
+    b = ['b', 'c']
+    ali = align(a, b, EPS)
+    assert ali == [('a', EPS), ('b', 'b'), (EPS, 'c')]
+    dist = edit_distance(a, b)
+    assert dist == {'ins': 1, 'del': 1, 'sub': 0, 'total': 2}
+
+    a = ['A' ,'B','C']
+    b = ['D' ,'C', 'A']
+    ali = align(a, b, EPS)
+    assert ali == [('A', 'D'), ('B', EPS), ('C', 'C'), (EPS, 'A')]
+    dist = edit_distance(a, b)
+    assert dist == {'ins': 1, 'del': 1, 'sub': 1, 'total': 3}
+
+
+    a = ['A', 'B', 'C',  'D']
+    b = ['C', 'E', 'D', 'F']
+    ali = align(a, b, EPS)
+    assert ali == [('A', EPS), ('B', EPS), ('C', 'C'), (EPS, 'E'), ('D', 'D'), (EPS, 'F')]
+    dist = edit_distance(a, b)
+    assert dist == {'ins': 2, 'del': 2, 'sub': 0, 'total': 4}
 
 
 def test_edit_distance():
@@ -20,3 +44,9 @@ def test_edit_distance():
         'sub': 1,
         'total': 2
     }
+
+
+if __name__ == '__main__':
+    test_align()
+    test_edit_distance()
+


### PR DESCRIPTION
For cases which has multi-alignments resulting same wer, function edit_distance and align may give inconsistent detail results([example test-cases on colab).](https://colab.research.google.com/drive/1iTXTZvUf2rm-_DMJsMJ5LWb4p3u2y14D?usp=sharing). i.e. different sub/ins/del errors though total are the same.
I think the reason is following. 
If there are multi-alignments with identical total wer,  
in funtion edit_distance, the priority is more_ins [> ](https://github.com/kaldi-asr/kaldi/blob/ea2b433dfdd7eab4c7a665ef46f7e87a2e4a782e/src/util/edit-distance-inl.h#L111)more_del [>](https://github.com/kaldi-asr/kaldi/blob/master/src/util/edit-distance-inl.h#L106) more_sub(I think this one is better); 
while in function align, the priority is more_sub [>](https://github.com/kaldi-asr/kaldi/blob/master/src/util/edit-distance-inl.h#L173) more_del [>](https://github.com/kaldi-asr/kaldi/blob/master/src/util/edit-distance-inl.h#L177) more_ins;

Anyway, this is not urgent and only leads to inconsistent results but not wrong results.
Both functions get CORRECT total edit-distance.