### PR TITLE
Fix a bug that CMakeLists.txt could not be found when the package was installed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project(kaldialign CXX)
 
-set(KALDIALIGN_VERSION "0.3")
+set(KALDIALIGN_VERSION "0.4")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include LICENSE
 include extensions/*
 include tests/*
+include CMakeLists.txt
+recursive-include cmake *.*


### PR DESCRIPTION
Resolve #4 

There is a bug that the package `kaldialign-0.3` has not been installed since the PR #3 was reflected.

Adding `CmakeLists.txt` to `MANIFEST.in` seems to resolve this problem.

I have checked that the package is well built and installed in my local environment.
```
$ cd kaldialign
$ python setup.py bdist_wheel
...
$ pip install dist/kaldialign-0.4-cp39-cp39-macosx_12_0_x86_64.whl
...
Successfully installed kaldialign-0.4
```

Please double check if the package is well built and installed in your environment.

cc. @pzelasko  @csukuangfj 