### PR TITLE
Publish pre-built wheels

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -42,13 +42,13 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-      # - name: Publish wheels to PyPI
-      #   env:
-      #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      #   shell: bash
-      #   run: |
-      #     python3 -m pip install --upgrade pip
-      #     python3 -m pip install wheel twine setuptools
-      #
-      #     twine upload ./wheelhouse/*.whl
+      - name: Publish wheels to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        shell: bash
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install wheel twine setuptools
+
+          twine upload ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - wheel
-      - pre-built-wheels-2023-01-10
     tags:
       - '*'
 

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -1,0 +1,55 @@
+name: build-wheels
+
+on:
+  push:
+    branches:
+      - wheel
+      - pre-built-wheels-2023-01-10
+    tags:
+      - '*'
+
+concurrency:
+  group: build-wheels-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
+      # for a list of versions
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.11.4
+        env:
+          CIBW_SKIP: "cp27-* cp35-* *-win32 pp* *-musllinux*"
+          CIBW_BUILD_VERBOSITY: 3
+
+      - name: Display wheels
+        shell: bash
+        run: |
+          ls -lh ./wheelhouse/
+
+          ls -lh ./wheelhouse/*.whl
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+      # - name: Publish wheels to PyPI
+      #   env:
+      #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      #   shell: bash
+      #   run: |
+      #     python3 -m pip install --upgrade pip
+      #     python3 -m pip install wheel twine setuptools
+      #
+      #     twine upload ./wheelhouse/*.whl

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-10.15]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       # refer to https://github.com/actions/checkout
@@ -30,6 +30,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          channels: conda-forge
           activate-environment: kaldialign
 
       - name: Display Python version

--- a/.github/workflows/build_conda_ubuntu.yml
+++ b/.github/workflows/build_conda_ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       # refer to https://github.com/actions/checkout
@@ -30,6 +30,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          channels: conda-forge
           activate-environment: kaldialign
 
       - name: Display Python version

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       # refer to https://github.com/actions/checkout
@@ -30,6 +30,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          channels: conda-forge
           activate-environment: kaldialign
 
       - name: Display Python version

--- a/.github/workflows/test-pip-install.yaml
+++ b/.github/workflows/test-pip-install.yaml
@@ -1,0 +1,57 @@
+name: test-pip-install
+
+on:
+  push:
+    branches:
+      - nightly
+  schedule:
+    # minute (0-59)
+    # hour (0-23)
+    # day of the month (1-31)
+    # month (1-12)
+    # day of the week (0-6)
+    # nightly test at 22:50 UTC time every day
+    - cron: "50 22 * * *"
+
+concurrency:
+  group: test_pip_install-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test_pip_install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install kaldialign
+        shell: bash
+        run: |
+          pip3 install --verbose kaldialign
+
+      - name: Run test
+        shell: bash
+        run: |
+          python3 -c "import kaldialign; print(kaldialign.__file__)"
+          python3 -c "import kaldialign; print(kaldialign.__version__)"
+
+          cd tests
+          python3 ./test_align.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,12 +28,6 @@ pybind11_add_module(_kaldialign
   ./extensions/kaldialign.cpp
 )
 
-if(UNIX AND NOT APPLE)
-  target_link_libraries(_kaldialign PUBLIC ${PYTHON_LIBRARY})
-elseif(WIN32)
-  target_link_libraries(_kaldialign PUBLIC ${PYTHON_LIBRARIES})
-endif()
-
 install(TARGETS _kaldialign
   DESTINATION ../
 )

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -5,8 +5,8 @@ function(download_pybind11)
 
   include(FetchContent)
 
-  set(pybind11_URL  "https://github.com/pybind/pybind11/archive/v2.6.0.tar.gz")
-  set(pybind11_HASH "SHA256=90b705137b69ee3b5fc655eaca66d0dc9862ea1759226f7ccd3098425ae69571")
+  set(pybind11_URL  "https://github.com/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz")
+  set(pybind11_HASH "SHA256=93bd1e625e43e03028a3ea7389bba5d3f9f2596abc074b068e70f4ef9b1314ae")
 
   FetchContent_Declare(pybind11
     URL               ${pybind11_URL}


### PR DESCRIPTION
This PR publishes pre-built wheels to PyPI, like what we are doing for anaconda.

The advantage is that users don't need to install CMake or a C++ compiler any more. Also, it is faster to install.

@pzelasko 

You need to do the following on your side.

1. Visit https://github.com/pzelasko/kaldialign/settings/secrets/actions
2. Click the green button: New repository secret.

Please add two secret.
## Secret 1
- Key: PYPI_USERNAME
- Value: Your user name  for PyPI

## Secret 2
- Key: PYPI_PASSWORD
- Value: your password for PyPI

---

To release a new version, e.g., 0.6, please do the following

1. Change
https://github.com/pzelasko/kaldialign/blob/bc6a31f7b765d48ee194b31108e282c7f26a2bc3/CMakeLists.txt#L17
to
```
 set(KALDIALIGN_VERSION "0.6") 
```

2. Change
https://github.com/pzelasko/kaldialign/blob/bc6a31f7b765d48ee194b31108e282c7f26a2bc3/scripts/conda/kaldialign/meta.yaml#L3
to
```
 version: "0.6" 
```

3.
```
git add CMakeLists.txt
git add scripts/conda/kaldialign/meta.yaml
git commit -m "Release v0.6"
git push 
git tag v0.6
git push origin v0.6
```

It will upload the pre-built wheels to anaconda and PyPI, magically.