### PR TITLE
fix building wheels

### DIFF
--- a/.github/workflows/build-wheels-aarch64.yaml
+++ b/.github/workflows/build-wheels-aarch64.yaml
@@ -15,15 +15,16 @@ concurrency:
 
 jobs:
   build_wheels_aarch64:
-    name: Build wheels for aarch64 on ${{ matrix.os }}
+    name: ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -33,10 +34,11 @@ jobs:
       # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
       # for a list of versions
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
           CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
+          CIBW_BUILD: "${{ matrix.python-version}}-* "
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: aarch64
 
@@ -45,8 +47,9 @@ jobs:
         run: |
           ls -lh ./wheelhouse/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheel-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
 
       - name: Publish wheels to PyPI

--- a/.github/workflows/build-wheels-macos.yaml
+++ b/.github/workflows/build-wheels-macos.yaml
@@ -15,21 +15,21 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest]
+        python-version: ["cp38", "cp39", "cp310", "cp311", "cp312"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
-      # for a list of versions
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.16.5
         env:
+          CIBW_BUILD: "${{ matrix.python-version}}-* "
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
           CIBW_ENVIRONMENT: KALDIALIGN_CMAKE_ARGS="-DCMAKE_OSX_ARCHITECTURES='arm64;x86_64'"
           CIBW_ARCHS: "universal2"
@@ -43,8 +43,9 @@ jobs:
         run: |
           ls -lh ./wheelhouse/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheel-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
 
       - name: Publish wheels to PyPI

--- a/.github/workflows/build-wheels-win32.yaml
+++ b/.github/workflows/build-wheels-win32.yaml
@@ -15,22 +15,24 @@ concurrency:
 
 jobs:
   build_wheels_win32:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest]
+        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
       # for a list of versions
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
+          CIBW_BUILD: "${{ matrix.python-version}}-* "
           CIBW_ENVIRONMENT: KALDIALIGN_CMAKE_ARGS="-A Win32"
           CIBW_SKIP: "*-win_amd64"
           CIBW_BUILD_VERBOSITY: 3
@@ -40,8 +42,9 @@ jobs:
         run: |
           ls -lh ./wheelhouse/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheel-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
 
       - name: Publish wheels to PyPI

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -15,22 +15,24 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: ${{ matrix.os }} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
       # for a list of versions
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_SKIP: "cp27-* cp35-* *-win32 pp* *-musllinux*"
+          CIBW_BUILD: "${{ matrix.python-version}}-* "
+          CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
           CIBW_BUILD_VERBOSITY: 3
 
       - name: Display wheels
@@ -38,9 +40,17 @@ jobs:
         run: |
           ls -lh ./wheelhouse/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheel-${{ matrix.os }}-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
+
+      - name: Build sdist
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        shell: bash
+        run: |
+          python3 setup.py sdist
+          ls -lh dist/*
 
       - name: Publish wheels to PyPI
         env:
@@ -53,15 +63,9 @@ jobs:
 
           twine upload ./wheelhouse/*.whl
 
-      - name: Build sdist
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        shell: bash
-        run: |
-          python3 setup.py sdist
-          ls -lh dist/*
 
       - name: Publish sdist to PyPI
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build_conda_macos.yml
+++ b/.github/workflows/build_conda_macos.yml
@@ -6,6 +6,7 @@ on:
       - '*'
     branches:
       - conda
+  workflow_dispatch:
 
 concurrency:
   group: build_conda_macos-${{ github.ref }}
@@ -13,12 +14,13 @@ concurrency:
 
 jobs:
   build_conda_macos:
+    name: ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-12]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       # refer to https://github.com/actions/checkout

--- a/.github/workflows/build_conda_ubuntu.yml
+++ b/.github/workflows/build_conda_ubuntu.yml
@@ -6,6 +6,7 @@ on:
       - '*'
     branches:
       - conda
+  workflow_dispatch:
 
 concurrency:
   group: build_conda_ubuntu-${{ github.ref }}
@@ -13,16 +14,17 @@ concurrency:
 
 jobs:
   build_conda_ubuntu:
+    name: ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       # refer to https://github.com/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build_conda_windows.yml
+++ b/.github/workflows/build_conda_windows.yml
@@ -7,22 +7,25 @@ on:
     branches:
       - conda
 
+  workflow_dispatch:
+
 concurrency:
   group: build_conda_windows-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build_conda_windows:
+    name: ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-2019]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       # refer to https://github.com/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-pip-install.yaml
+++ b/.github/workflows/test-pip-install.yaml
@@ -13,6 +13,8 @@ on:
     # nightly test at 22:50 UTC time every day
     - cron: "50 22 * * *"
 
+  workflow_dispatch:
+
 concurrency:
   group: test_pip_install-${{ github.ref }}
   cancel-in-progress: true
@@ -22,20 +24,24 @@ permissions:
 
 jobs:
   test_pip_install:
+    name: ${{ matrix.os }} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.7"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,17 +8,22 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+
 jobs:
   run-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-      fail-fast: false
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.7"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # see https://github.com/microsoft/setup-msbuild
       - name: Add msbuild to PATH
@@ -26,7 +31,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Fix https://github.com/pzelasko/kaldialign/actions/runs/8143907683

Also, add python 3.12 support.

Note there is no need to push a new tag to trigger the CI.

All you need to do is

(1) Merge this PR into the `main` branch
(2) Visit https://github.com/pzelasko/kaldialign/actions
(3) Follow the following screenshot
![Screenshot 2024-03-05 at 15 21 15](https://github.com/pzelasko/kaldialign/assets/5284924/7a4f4364-05b6-49be-bd2d-9f926ab0acb9)


(4) Done