### PR TITLE
Option to discard compound word inconsistencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 project(kaldialign CXX)
 
 # Please remember to also change line 3 of ./scripts/conda/kaldialign/meta.yaml
-set(KALDIALIGN_VERSION "0.9.3")
+set(KALDIALIGN_VERSION "0.10.0")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,37 @@ assert results == {
 For alignment and edit distance, you can pass `sclite_mode=True` to compute WER or alignments
 based on SCLITE style weights, i.e., insertion/deletion cost 3 and substitution cost 4.
 
+### Compound word matching
+
+All functions accept `merge_compounds=True` to allow adjacent words in either sequence to be
+concatenated (without separator) to match a single word in the other sequence at zero cost.
+This is useful whenever there are inconsistencies within transcriptions,
+or between training and testing conditions of a model evaluated with WER.
+
+```python
+from kaldialign import edit_distance, align
+
+# "white paper" (2 words) matches "whitepaper" (1 word) with 0 errors
+ref = ["the", "white", "paper", "is", "good"]
+hyp = ["the", "whitepaper", "is", "good"]
+
+results = edit_distance(ref, hyp, merge_compounds=True)
+assert results["total"] == 0
+
+# Works in both directions
+results = edit_distance(hyp, ref, merge_compounds=True)
+assert results["total"] == 0
+
+# Alignment shows compound matches as space-joined strings
+ali = align(ref, hyp, "*", merge_compounds=True)
+assert ali == [
+    ("the", "the"),
+    ("white paper", "whitepaper"),
+    ("is", "is"),
+    ("good", "good"),
+]
+```
+
 ### Bootstrapping method to extract WER 95% confidence intervals
 
 `boostrap_wer_ci(ref, hyp, hyp2=None)` - obtain the 95% confidence intervals for WER using Bisani and Ney boostrapping method.
@@ -86,6 +117,8 @@ assert ans["ci95"] == 0.2312
 assert ans["ci95min"] == 0.2678
 assert ans["ci95max"] == 0.7301
 ```
+
+All bootstrap functions also accept `merge_compounds=True`.
 
 It also supports providing hypotheses from system 1 and system 2 to compute the probability of S2 improving over S1:
 

--- a/benchmarks/bench_compound.py
+++ b/benchmarks/bench_compound.py
@@ -1,0 +1,104 @@
+"""
+Benchmark: compound-aware WER (C++ string-based) vs standard WER (C++ int-based).
+
+Generates a synthetic dataset of sentence pairs with random compound merges,
+then times both edit_distance paths over all pairs.
+
+Usage:
+    python benchmarks/bench_compound.py
+"""
+
+import random
+import time
+
+from kaldialign import edit_distance
+
+# fmt: off
+VOCAB = [
+    "the", "a", "an", "is", "was", "are", "were", "has", "have", "had",
+    "do", "does", "did", "will", "would", "can", "could", "may", "might",
+    "shall", "should", "must", "be", "been", "being", "get", "got",
+    "go", "going", "come", "make", "take", "give", "see", "know",
+    "think", "say", "tell", "find", "want", "use", "put", "work",
+    "call", "try", "ask", "need", "run", "move", "live", "turn",
+    "play", "point", "read", "show", "change", "set", "help", "name",
+    "line", "end", "hand", "home", "side", "head", "eye", "back",
+    "door", "room", "face", "water", "white", "paper", "long", "over",
+    "black", "little", "right", "old", "big", "high", "new", "small",
+]
+# fmt: on
+
+
+def generate_dataset(n_pairs, min_len, max_len, compound_prob, seed):
+    """
+    Generate synthetic ref/hyp pairs.
+
+    With probability ``compound_prob``, 2-3 adjacent ref words are fused
+    into a single hyp word (or vice versa), exercising compound matching.
+    """
+    rng = random.Random(seed)
+    pairs = []
+
+    for _ in range(n_pairs):
+        length = rng.randint(min_len, max_len)
+        ref = [rng.choice(VOCAB) for _ in range(length)]
+        hyp = list(ref)  # start from a copy
+
+        # Randomly introduce substitutions (10% of words).
+        for i in range(len(hyp)):
+            if rng.random() < 0.1:
+                hyp[i] = rng.choice(VOCAB)
+
+        # Randomly introduce compound merges.
+        if rng.random() < compound_prob:
+            n_merges = rng.randint(1, max(1, length // 5))
+            for _ in range(n_merges):
+                if len(hyp) < 3:
+                    break
+                merge_len = rng.randint(2, min(3, len(hyp)))
+                pos = rng.randint(0, len(hyp) - merge_len)
+                merged = "".join(hyp[pos : pos + merge_len])
+                hyp = hyp[:pos] + [merged] + hyp[pos + merge_len :]
+
+        pairs.append((ref, hyp))
+
+    return pairs
+
+
+def bench(pairs, label, **kwargs):
+    """Time edit_distance over all pairs, print results."""
+    # Warmup
+    for ref, hyp in pairs[:10]:
+        edit_distance(ref, hyp, **kwargs)
+
+    start = time.perf_counter()
+    for ref, hyp in pairs:
+        edit_distance(ref, hyp, **kwargs)
+    elapsed = time.perf_counter() - start
+
+    n = len(pairs)
+    print(
+        f"  {label:30s}  total={elapsed:.4f}s  "
+        f"per_pair={elapsed / n * 1e6:.1f}us  "
+        f"({n} pairs)"
+    )
+    return elapsed
+
+
+def main():
+    for n_pairs in [500, 1000, 2000]:
+        print(f"\n--- {n_pairs} pairs (10-30 words each) ---")
+        pairs = generate_dataset(
+            n_pairs=n_pairs,
+            min_len=10,
+            max_len=30,
+            compound_prob=0.3,
+            seed=42,
+        )
+        t_std = bench(pairs, "C++ standard (int-based)", merge_compounds=False)
+        t_cmp = bench(pairs, "C++ compound (string-based)", merge_compounds=True)
+        print(f"  {'overhead ratio':30s}  {t_cmp / t_std:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/extensions/kaldi_align.cpp
+++ b/extensions/kaldi_align.cpp
@@ -157,6 +157,240 @@ int LevenshteinAlignment(const std::vector<int> &a,
   return e[M][N];
 }
 
+int LevenshteinEditDistanceCompound(
+    const std::vector<std::string> &ref,
+    const std::vector<std::string> &hyp,
+    const bool sclite_mode,
+    int *ins, int *del, int *sub) {
+
+  int ins_cost, del_cost, sub_cost;
+  if (sclite_mode) {
+    ins_cost = INS_COST_SCLITE;
+    del_cost = DEL_COST_SCLITE;
+    sub_cost = SUB_COST_SCLITE;
+  } else {
+    ins_cost = INS_COST;
+    del_cost = DEL_COST;
+    sub_cost = SUB_COST;
+  }
+
+  size_t M = ref.size(), N = hyp.size();
+
+  // Full 2D table (compound transitions access arbitrary previous rows).
+  std::vector<std::vector<error_stats>> e(M + 1, std::vector<error_stats>(N + 1));
+
+  // Initialize first column: deleting ref words.
+  for (size_t i = 0; i <= M; i++) {
+    e[i][0].ins_num = 0;
+    e[i][0].sub_num = 0;
+    e[i][0].del_num = i;
+    e[i][0].total_num = i;
+    e[i][0].total_cost = i * del_cost;
+  }
+  // Initialize first row: inserting hyp words.
+  for (size_t j = 0; j <= N; j++) {
+    e[0][j].ins_num = j;
+    e[0][j].sub_num = 0;
+    e[0][j].del_num = 0;
+    e[0][j].total_num = j;
+    e[0][j].total_cost = j * ins_cost;
+  }
+
+  for (size_t i = 1; i <= M; i++) {
+    for (size_t j = 1; j <= N; j++) {
+      // --- Standard transitions ---
+      int sub_err = e[i-1][j-1].total_cost;
+      if (ref[i-1] != hyp[j-1])
+        sub_err += sub_cost;
+      int del_err = e[i-1][j].total_cost + del_cost;
+      int ins_err = e[i][j-1].total_cost + ins_cost;
+
+      if (sub_err < ins_err && sub_err < del_err) {
+        e[i][j] = e[i-1][j-1];
+        if (ref[i-1] != hyp[j-1]) {
+          e[i][j].sub_num++;
+          e[i][j].total_num++;
+        }
+        e[i][j].total_cost = sub_err;
+      } else if (del_err < ins_err) {
+        e[i][j] = e[i-1][j];
+        e[i][j].del_num++;
+        e[i][j].total_num++;
+        e[i][j].total_cost = del_err;
+      } else {
+        e[i][j] = e[i][j-1];
+        e[i][j].ins_num++;
+        e[i][j].total_num++;
+        e[i][j].total_cost = ins_err;
+      }
+
+      // --- Compound: k ref words -> 1 hyp word ---
+      {
+        std::string merged = ref[i-1];
+        for (size_t k = 2; k <= i; k++) {
+          merged = ref[i-k] + merged;
+          if (merged.size() > hyp[j-1].size()) break;
+          if (merged == hyp[j-1]) {
+            if (e[i-k][j-1].total_cost < e[i][j].total_cost) {
+              e[i][j] = e[i-k][j-1];  // inherit stats, 0 new errors
+            }
+          }
+        }
+      }
+
+      // --- Compound: k hyp words -> 1 ref word ---
+      {
+        std::string merged = hyp[j-1];
+        for (size_t k = 2; k <= j; k++) {
+          merged = hyp[j-k] + merged;
+          if (merged.size() > ref[i-1].size()) break;
+          if (merged == ref[i-1]) {
+            if (e[i-1][j-k].total_cost < e[i][j].total_cost) {
+              e[i][j] = e[i-1][j-k];  // inherit stats, 0 new errors
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (ins != nullptr) *ins = e[M][N].ins_num;
+  if (del != nullptr) *del = e[M][N].del_num;
+  if (sub != nullptr) *sub = e[M][N].sub_num;
+  return e[M][N].total_num;
+}
+
+
+int LevenshteinAlignmentCompound(
+    const std::vector<std::string> &a,
+    const std::vector<std::string> &b,
+    const std::string &eps_symbol,
+    const bool sclite_mode,
+    std::vector<std::pair<std::string, std::string>> *output) {
+
+  assert(output != NULL);
+  output->clear();
+
+  int ins_cost, del_cost, sub_cost;
+  if (sclite_mode) {
+    ins_cost = INS_COST_SCLITE;
+    del_cost = DEL_COST_SCLITE;
+    sub_cost = SUB_COST_SCLITE;
+  } else {
+    ins_cost = INS_COST;
+    del_cost = DEL_COST;
+    sub_cost = SUB_COST;
+  }
+
+  size_t M = a.size(), N = b.size();
+
+  // Cost table.
+  std::vector<std::vector<int>> e(M + 1, std::vector<int>(N + 1));
+  // Backpointer table.
+  struct BackPointer {
+    size_t prev_m;
+    size_t prev_n;
+  };
+  std::vector<std::vector<BackPointer>> bp(M + 1, std::vector<BackPointer>(N + 1));
+
+  for (size_t n = 0; n <= N; n++)
+    e[0][n] = n * ins_cost;
+  for (size_t m = 1; m <= M; m++)
+    e[m][0] = m * del_cost;
+  // backpointers for borders
+  for (size_t n = 1; n <= N; n++)
+    bp[0][n] = {0, n - 1};
+  for (size_t m = 1; m <= M; m++)
+    bp[m][0] = {m - 1, 0};
+
+  for (size_t m = 1; m <= M; m++) {
+    for (size_t n = 1; n <= N; n++) {
+      int sub_or_ok = e[m-1][n-1] + (a[m-1] == b[n-1] ? 0 : sub_cost);
+      int del = e[m-1][n] + del_cost;
+      int ins = e[m][n-1] + ins_cost;
+
+      // Choose best standard transition (prefer match/sub > del > ins).
+      if (sub_or_ok < std::min(del, ins)) {
+        e[m][n] = sub_or_ok;
+        bp[m][n] = {m - 1, n - 1};
+      } else if (del < ins) {
+        e[m][n] = del;
+        bp[m][n] = {m - 1, n};
+      } else {
+        e[m][n] = ins;
+        bp[m][n] = {m, n - 1};
+      }
+
+      // Compound: k ref words -> 1 hyp word.
+      {
+        std::string merged = a[m-1];
+        for (size_t k = 2; k <= m; k++) {
+          merged = a[m-k] + merged;
+          if (merged.size() > b[n-1].size()) break;
+          if (merged == b[n-1]) {
+            if (e[m-k][n-1] < e[m][n]) {
+              e[m][n] = e[m-k][n-1];
+              bp[m][n] = {m - k, n - 1};
+            }
+          }
+        }
+      }
+
+      // Compound: k hyp words -> 1 ref word.
+      {
+        std::string merged = b[n-1];
+        for (size_t k = 2; k <= n; k++) {
+          merged = b[n-k] + merged;
+          if (merged.size() > a[m-1].size()) break;
+          if (merged == a[m-1]) {
+            if (e[m-1][n-k] < e[m][n]) {
+              e[m][n] = e[m-1][n-k];
+              bp[m][n] = {m - 1, n - k};
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Traceback.
+  size_t m = M, n = N;
+  while (m != 0 || n != 0) {
+    size_t pm = bp[m][n].prev_m;
+    size_t pn = bp[m][n].prev_n;
+    size_t ref_consumed = m - pm;
+    size_t hyp_consumed = n - pn;
+
+    if (ref_consumed > 1 && hyp_consumed == 1) {
+      // Compound: multiple ref words -> 1 hyp word.
+      std::string ref_str;
+      for (size_t idx = pm; idx < m; idx++) {
+        if (!ref_str.empty()) ref_str += " ";
+        ref_str += a[idx];
+      }
+      output->push_back({ref_str, b[pn]});
+    } else if (ref_consumed == 1 && hyp_consumed > 1) {
+      // Compound: 1 ref word -> multiple hyp words.
+      std::string hyp_str;
+      for (size_t idx = pn; idx < n; idx++) {
+        if (!hyp_str.empty()) hyp_str += " ";
+        hyp_str += b[idx];
+      }
+      output->push_back({a[pm], hyp_str});
+    } else {
+      // Standard transition.
+      std::string a_sym = (pm == m) ? eps_symbol : a[pm];
+      std::string b_sym = (pn == n) ? eps_symbol : b[pn];
+      output->push_back({a_sym, b_sym});
+    }
+    m = pm;
+    n = pn;
+  }
+  ReverseVector(output);
+  return e[M][N];
+}
+
+
 namespace internal {
 
     std::vector<std::pair<int, int>> GetEdits(
@@ -168,6 +402,20 @@ namespace internal {
             const auto &ref = refs[i];
             const auto dist = LevenshteinEditDistance(ref, hyps[i], false, nullptr, nullptr, nullptr);
             ans.emplace_back(dist, ref.size());
+        }
+        return ans;
+    }
+
+    std::vector<std::pair<int, int>> GetEditsCompound(
+        const std::vector<std::vector<std::string>> &refs,
+        const std::vector<std::vector<std::string>> &hyps
+    ) {
+        std::vector<std::pair<int, int>> ans;
+        for (size_t i = 0; i != refs.size(); ++i) {
+            const auto &ref = refs[i];
+            const auto dist = LevenshteinEditDistanceCompound(
+                ref, hyps[i], false, nullptr, nullptr, nullptr);
+            ans.emplace_back(dist, static_cast<int>(ref.size()));
         }
         return ans;
     }

--- a/extensions/kaldi_align.h
+++ b/extensions/kaldi_align.h
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <string>
 #include <utility>
 #include <vector>
 #include <cassert>
@@ -44,10 +45,33 @@ int LevenshteinAlignment(const std::vector<int> &a,
                          std::vector<std::pair<int, int> > *output);
 
 
+// Compound-aware variants (string-based).
+// Adjacent words in either sequence can be concatenated to match a single
+// word in the other sequence at zero cost.
+
+int LevenshteinEditDistanceCompound(
+    const std::vector<std::string> &ref,
+    const std::vector<std::string> &hyp,
+    const bool sclite_mode,
+    int *ins, int *del, int *sub);
+
+int LevenshteinAlignmentCompound(
+    const std::vector<std::string> &a,
+    const std::vector<std::string> &b,
+    const std::string &eps_symbol,
+    const bool sclite_mode,
+    std::vector<std::pair<std::string, std::string>> *output);
+
+
 namespace internal{
     std::vector<std::pair<int, int>> GetEdits(
         const std::vector<std::vector<int>> &refs,
         const std::vector<std::vector<int>> &hyps
+    );
+
+    std::vector<std::pair<int, int>> GetEditsCompound(
+        const std::vector<std::vector<std::string>> &refs,
+        const std::vector<std::vector<std::string>> &hyps
     );
 
     std::pair<double, double> GetBootstrapWerInterval(

--- a/extensions/kaldialign.cpp
+++ b/extensions/kaldialign.cpp
@@ -51,6 +51,37 @@ static double GetPImprov(
     return internal::GetPImprov(edit_sym_per_hyp, edit_sym_per_hyp2, replications, seed);
 }
 
+static py::dict EditDistanceCompound(const std::vector<std::string> &a,
+                                      const std::vector<std::string> &b,
+                                      const bool sclite_mode) {
+  int ins;
+  int del;
+  int sub;
+
+  int total = LevenshteinEditDistanceCompound(a, b, sclite_mode, &ins, &del, &sub);
+  py::dict ans;
+  ans["ins"] = ins;
+  ans["del"] = del;
+  ans["sub"] = sub;
+  ans["total"] = total;
+  return ans;
+}
+
+static std::vector<std::pair<std::string, std::string>>
+AlignCompound(const std::vector<std::string> &a, const std::vector<std::string> &b,
+              const std::string &eps_symbol, const bool sclite_mode) {
+  std::vector<std::pair<std::string, std::string>> ans;
+  LevenshteinAlignmentCompound(a, b, eps_symbol, sclite_mode, &ans);
+  return ans;
+}
+
+static std::vector<std::pair<int, int>> GetEditsCompound(
+    const std::vector<std::vector<std::string>> &refs,
+    const std::vector<std::vector<std::string>> &hyps
+) {
+    return internal::GetEditsCompound(refs, hyps);
+}
+
 PYBIND11_MODULE(_kaldialign, m) {
   m.doc() = "Python wrapper for kaldialign";
   m.def("edit_distance", &EditDistance, py::arg("a"), py::arg("b"), py::arg("sclite_mode") = false);
@@ -58,4 +89,7 @@ PYBIND11_MODULE(_kaldialign, m) {
   m.def("_get_edits", &GetEdits, py::arg("refs"), py::arg("hyps"));
   m.def("_get_boostrap_wer_interval", &GetBootstrapWerInterval, py::arg("edit_sym_per_hyp"), py::arg("replications") = 10000, py::arg("seed") = 0);
   m.def("_get_p_improv", &GetPImprov, py::arg("edit_sym_per_hyp"), py::arg("edit_sym_per_hyp2"), py::arg("replications") = 10000, py::arg("seed") = 0);
+  m.def("edit_distance_compound", &EditDistanceCompound, py::arg("a"), py::arg("b"), py::arg("sclite_mode") = false);
+  m.def("align_compound", &AlignCompound, py::arg("a"), py::arg("b"), py::arg("eps_symbol"), py::arg("sclite_mode") = false);
+  m.def("_get_edits_compound", &GetEditsCompound, py::arg("refs"), py::arg("hyps"));
 }

--- a/kaldialign/__init__.py
+++ b/kaldialign/__init__.py
@@ -8,7 +8,10 @@ Symbol = TypeVar("Symbol")
 
 
 def edit_distance(
-    ref: Iterable[Symbol], hyp: Iterable[Symbol], sclite_mode: bool = False
+    ref: Iterable[Symbol],
+    hyp: Iterable[Symbol],
+    sclite_mode: bool = False,
+    merge_compounds: bool = False,
 ) -> Dict[str, Union[int, float]]:
     """
     Compute the edit distance between sequences ``ref`` and ``hyp``.
@@ -16,6 +19,11 @@ def edit_distance(
 
     Optional ``sclite_mode`` sets INS/DEL/SUB costs to 3/3/4 for
     compatibility with sclite tool.
+
+    When ``merge_compounds`` is True, adjacent words in either sequence
+    may be concatenated (without separator) to match a single word in the
+    other sequence at zero cost.  For example, ``["white", "paper"]`` and
+    ``["whitepaper"]`` are treated as a match with 0 errors.
 
     Returns a dict with keys:
     * ``ins`` -- the number of insertions (in ``hyp`` vs ``ref``)
@@ -25,21 +33,23 @@ def edit_distance(
     * ``ref_len`` -- the number of symbols in ``ref``
     * ``err_rate`` -- the error rate  (total number of errors divided by ``ref_len``)
     """
-    int2sym = dict(enumerate(sorted(set(ref) | set(hyp))))
-    sym2int = {v: k for k, v in int2sym.items()}
+    ref = list(ref)
+    hyp = list(hyp)
 
-    refi: List[int] = []
-    hypi: List[int] = []
-    for sym in ref:
-        refi.append(sym2int[sym])
+    if merge_compounds:
+        ref_str = [str(s) for s in ref]
+        hyp_str = [str(s) for s in hyp]
+        ans = _kaldialign.edit_distance_compound(ref_str, hyp_str, sclite_mode)
+    else:
+        int2sym = dict(enumerate(sorted(set(ref) | set(hyp))))
+        sym2int = {v: k for k, v in int2sym.items()}
+        refi = [sym2int[sym] for sym in ref]
+        hypi = [sym2int[sym] for sym in hyp]
+        ans = _kaldialign.edit_distance(refi, hypi, sclite_mode)
 
-    for sym in hyp:
-        hypi.append(sym2int[sym])
-
-    ans = _kaldialign.edit_distance(refi, hypi, sclite_mode)
-    ans["ref_len"] = len(refi)
+    ans["ref_len"] = len(ref)
     try:
-        ans["err_rate"] = ans["total"] / len(refi)
+        ans["err_rate"] = ans["total"] / len(ref)
     except ZeroDivisionError:
         if ans["total"] == 0:
             ans["err_rate"] = 0.0
@@ -53,6 +63,7 @@ def align(
     hyp: Iterable[Symbol],
     eps_symbol: Symbol,
     sclite_mode: bool = False,
+    merge_compounds: bool = False,
 ) -> List[Tuple[Symbol, Symbol]]:
     """
     Compute the alignment between sequences ``ref`` and ``hyp``.
@@ -63,30 +74,32 @@ def align(
     Optional ``sclite_mode`` sets INS/DEL/SUB costs to 3/3/4 for
     compatibility with sclite tool.
 
+    When ``merge_compounds`` is True, adjacent words in either sequence may
+    be concatenated to match a single word in the other sequence at zero cost.
+    Compound-matched groups appear as space-joined strings in the output, e.g.
+    ``("white paper", "whitepaper")``.
+
     Returns a list of pairs of alignment symbols. The presence of ``eps_symbol``
     in the first pair index indicates insertion, and in the second pair index, deletion.
     Mismatched symbols indicate substitution.
     """
-    int2sym = dict(enumerate(sorted(set(ref) | set(hyp) | {eps_symbol})))
-    sym2int = {v: k for k, v in int2sym.items()}
+    ref = list(ref)
+    hyp = list(hyp)
 
-    ai: List[int] = []
-    bi: List[int] = []
-
-    for sym in ref:
-        ai.append(sym2int[sym])
-
-    for sym in hyp:
-        bi.append(sym2int[sym])
-
-    eps_int = sym2int[eps_symbol]
-    alignment: List[Tuple[int, int]] = _kaldialign.align(ai, bi, eps_int, sclite_mode)
-
-    ali = []
-    for idx in range(len(alignment)):
-        ali.append((int2sym[alignment[idx][0]], int2sym[alignment[idx][1]]))
-
-    return ali
+    if merge_compounds:
+        ref_str = [str(s) for s in ref]
+        hyp_str = [str(s) for s in hyp]
+        return _kaldialign.align_compound(
+            ref_str, hyp_str, str(eps_symbol), sclite_mode
+        )
+    else:
+        int2sym = dict(enumerate(sorted(set(ref) | set(hyp) | {eps_symbol})))
+        sym2int = {v: k for k, v in int2sym.items()}
+        ai = [sym2int[sym] for sym in ref]
+        bi = [sym2int[sym] for sym in hyp]
+        eps_int = sym2int[eps_symbol]
+        alignment = _kaldialign.align(ai, bi, eps_int, sclite_mode)
+        return [(int2sym[a], int2sym[b]) for a, b in alignment]
 
 
 def bootstrap_wer_ci(
@@ -95,6 +108,7 @@ def bootstrap_wer_ci(
     hyps2: Optional[Sequence[Sequence[Symbol]]] = None,
     replications: int = 10000,
     seed: int = 0,
+    merge_compounds: bool = False,
 ) -> Dict:
     """
     Compute a boostrapping of WER to extract the 95% confidence interval (CI)
@@ -109,6 +123,8 @@ def bootstrap_wer_ci(
             of system2 improving over system1.
         replications: The number of replications to use for bootstrapping.
         seed: The random seed to reproduce the results.
+        merge_compounds: When True, adjacent words may be concatenated to match
+            a single compound word at zero cost (see :func:`edit_distance`).
 
     Returns:
         A dict with results. When scoring a single system (``hyp2_seqs=None``), the keys are:
@@ -125,7 +141,12 @@ def bootstrap_wer_ci(
 
     [2] https://github.com/kaldi-asr/kaldi/blob/master/src/bin/compute-wer-bootci.cc
     """
-    from _kaldialign import _get_boostrap_wer_interval, _get_edits, _get_p_improv
+    from _kaldialign import (
+        _get_boostrap_wer_interval,
+        _get_edits,
+        _get_edits_compound,
+        _get_p_improv,
+    )
 
     assert len(hyps) == len(
         refs
@@ -136,9 +157,14 @@ def bootstrap_wer_ci(
         hyps, str
     ), "The input must be a list of strings or list of lists of ints."
 
-    refs, hyps, hyps2 = _convert_to_int(refs, hyps, hyps2)
+    if merge_compounds:
+        refs_s = [[str(s) for s in seq] for seq in refs]
+        hyps_s = [[str(s) for s in seq] for seq in hyps]
+        edit_sym_per_hyp = _get_edits_compound(refs_s, hyps_s)
+    else:
+        refs_i, hyps_i, hyps2_i = _convert_to_int(refs, hyps, hyps2)
+        edit_sym_per_hyp = _get_edits(refs_i, hyps_i)
 
-    edit_sym_per_hyp = _get_edits(refs, hyps)
     mean, interval = _get_boostrap_wer_interval(
         edit_sym_per_hyp, replications=replications, seed=seed
     )
@@ -149,7 +175,13 @@ def bootstrap_wer_ci(
     assert len(hyps2) == len(
         refs
     ), f"Inconsistent number of reference ({len(refs)}) and hypothesis ({len(hyps2)}) sequences for the second system (hyp2_seqs)."
-    edit_sym_per_hyp2 = _get_edits(refs, hyps2)
+
+    if merge_compounds:
+        hyps2_s = [[str(s) for s in seq] for seq in hyps2]
+        edit_sym_per_hyp2 = _get_edits_compound(refs_s, hyps2_s)
+    else:
+        edit_sym_per_hyp2 = _get_edits(refs_i, hyps2_i)
+
     mean2, interval2 = _get_boostrap_wer_interval(
         edit_sym_per_hyp2, replications=replications, seed=seed
     )

--- a/scripts/conda/kaldialign/meta.yaml
+++ b/scripts/conda/kaldialign/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: kaldialign
-  version: "0.9.3"
+  version: "0.10.0"
 
 source:
   path: "{{ environ.get('KALDIALIGN_ROOT_DIR') }}"

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -184,3 +184,106 @@ def test_bootstrap_wer_ci_2system():
 
     assert ans["p_s2_improv_over_s1"] == 1.0
 
+
+# --- Compound word matching tests ---
+
+
+def test_edit_distance_compound_basic():
+    """Two ref words concatenate to match one hyp word."""
+    ref = ["white", "paper"]
+    hyp = ["whitepaper"]
+    dist = edit_distance(ref, hyp, merge_compounds=True)
+    assert dist == {
+        "ins": 0,
+        "del": 0,
+        "sub": 0,
+        "total": 0,
+        "ref_len": 2,
+        "err_rate": 0.0,
+    }
+
+
+def test_edit_distance_compound_reverse():
+    """One ref word matches two concatenated hyp words."""
+    ref = ["whitepaper"]
+    hyp = ["white", "paper"]
+    dist = edit_distance(ref, hyp, merge_compounds=True)
+    assert dist["total"] == 0
+    assert dist["ref_len"] == 1
+    assert dist["err_rate"] == 0.0
+
+
+def test_edit_distance_compound_mixed():
+    """Mix of compound matches and normal errors."""
+    ref = ["the", "white", "paper", "is", "here"]
+    hyp = ["the", "whitepaper", "was", "here"]
+    dist = edit_distance(ref, hyp, merge_compounds=True)
+    assert dist["total"] == 1
+    assert dist["sub"] == 1
+    assert dist["ins"] == 0
+    assert dist["del"] == 0
+
+
+def test_edit_distance_compound_three_words():
+    """Three ref words concatenate to match one hyp word."""
+    ref = ["a", "b", "c"]
+    hyp = ["abc"]
+    dist = edit_distance(ref, hyp, merge_compounds=True)
+    assert dist["total"] == 0
+
+
+def test_edit_distance_compound_no_false_positive():
+    """Without merge_compounds, normal edit distance applies."""
+    ref = ["white", "paper"]
+    hyp = ["whitepaper"]
+    dist = edit_distance(ref, hyp, merge_compounds=False)
+    assert dist["total"] == 2  # 1 sub + 1 del
+
+
+def test_edit_distance_compound_sclite():
+    """sclite_mode affects path selection but compound match is still 0 cost."""
+    ref = ["white", "paper", "is", "here"]
+    hyp = ["whitepaper", "was", "here"]
+    dist_normal = edit_distance(ref, hyp, merge_compounds=True)
+    dist_sclite = edit_distance(ref, hyp, sclite_mode=True, merge_compounds=True)
+    assert dist_normal["total"] == 1
+    assert dist_sclite["total"] == 1
+
+
+def test_align_compound():
+    ref = ["white", "paper"]
+    hyp = ["whitepaper"]
+    ali = align(ref, hyp, EPS, merge_compounds=True)
+    assert ali == [("white paper", "whitepaper")]
+
+
+def test_align_compound_reverse():
+    ref = ["whitepaper"]
+    hyp = ["white", "paper"]
+    ali = align(ref, hyp, EPS, merge_compounds=True)
+    assert ali == [("whitepaper", "white paper")]
+
+
+def test_align_compound_mixed():
+    ref = ["the", "white", "paper", "is", "here"]
+    hyp = ["the", "whitepaper", "was", "here"]
+    ali = align(ref, hyp, EPS, merge_compounds=True)
+    assert ali == [
+        ("the", "the"),
+        ("white paper", "whitepaper"),
+        ("is", "was"),
+        ("here", "here"),
+    ]
+
+
+def test_bootstrap_wer_ci_compound():
+    ref = [
+        ("white", "paper"),
+        ("hello", "world"),
+    ]
+    hyp = [
+        ("whitepaper",),
+        ("helloworld",),
+    ]
+    ans = bootstrap_wer_ci(ref, hyp, merge_compounds=True)
+    assert ans["wer"] == approx(0.0)


### PR DESCRIPTION
- Adds `merge_compounds=True` option to `edit_distance()`, `align()`, and `bootstrap_wer_ci()` that allows adjacent words in either sequence to be concatenated (without separator) to match a single word in the other sequence at zero cost. For example, `["t", "v"]` matches `["tv"]` with 0 errors.
- Implements compound-aware Levenshtein distance and alignment in C++ (`LevenshteinEditDistanceCompound`, `LevenshteinAlignmentCompound`) using a full 2D DP table with backpointers for multi-word compound transitions.
- Compound matches work bidirectionally (many-to-one in either ref or hyp) and compose with standard edit operations (ins/del/sub).
- Bumps version from 0.9.3 to 0.10.0.