### PR TITLE
Add `batch_error_rate` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,34 @@ assert results == {
 }
 ```
 
-For alignment and edit distance, you can pass `sclite_mode=True` to compute WER or alignments
-based on SCLITE style weights, i.e., insertion/deletion cost 3 and substitution cost 4.
+### Batch error rate
+
+`batch_error_rate(refs, hyps)` - used to obtain corpus-level error counts and error rate for a batch of reference/hypothesis sequence pairs. It computes error rate as the sum of all insertions, deletions, and substitutions divided by the total number of reference symbols.
+
+```python
+from kaldialign import batch_error_rate
+
+refs = [
+    ("a", "b", "c"),
+    ("d", "e"),
+]
+hyps = [
+    ("a", "x", "c", "y"),
+    ("d",),
+]
+results = batch_error_rate(refs, hyps)
+assert results == {
+    "ins": 1,
+    "del": 1,
+    "sub": 1,
+    "total": 3,
+    "ref_len": 5,
+    "err_rate": 0.6,
+}
+```
+
+For alignment, edit distance, and batch error rate, you can pass `sclite_mode=True` to compute
+WER or alignments based on SCLITE style weights, i.e., insertion/deletion cost 3 and substitution cost 4.
 
 ### Compound word matching
 

--- a/kaldialign/__init__.py
+++ b/kaldialign/__init__.py
@@ -54,13 +54,65 @@ def edit_distance(
         ans = _kaldialign.edit_distance(refi, hypi, sclite_mode)
 
     ans["ref_len"] = len(ref)
-    try:
-        ans["err_rate"] = ans["total"] / len(ref)
-    except ZeroDivisionError:
-        if ans["total"] == 0:
-            ans["err_rate"] = 0.0
-        else:
-            ans["err_rate"] = float("inf")
+    ans["err_rate"] = _compute_error_rate(ans["total"], len(ref))
+    return ans
+
+
+def batch_error_rate(
+    refs: Iterable[Iterable[Symbol]],
+    hyps: Iterable[Iterable[Symbol]],
+    sclite_mode: bool = False,
+    merge_compounds: bool = False,
+) -> Dict[str, Union[int, float]]:
+    """
+    Compute aggregate error rate between batches of reference and hypothesis
+    sequences.
+
+    Each pair is scored with :func:`edit_distance`, and the returned counts are
+    accumulated across the whole batch.  The aggregate ``err_rate`` is computed
+    as ``sum(ins + del + sub) / sum(ref_len)`` rather than as an average of
+    per-sequence error rates.
+
+    Optional ``sclite_mode`` and ``merge_compounds`` have the same meaning as in
+    :func:`edit_distance`.
+
+    Returns a dict with keys:
+    * ``ins`` -- the total number of insertions (in ``hyps`` vs ``refs``)
+    * ``del`` -- the total number of deletions (in ``hyps`` vs ``refs``)
+    * ``sub`` -- the total number of substitutions
+    * ``total`` -- total number of errors
+    * ``ref_len`` -- the total number of reference symbols
+    * ``err_rate`` -- the aggregate error rate
+    """
+    assert not isinstance(refs, str) and not isinstance(
+        hyps, str
+    ), "The input must be an iterable of reference and hypothesis sequences."
+
+    refs = list(refs)
+    hyps = list(hyps)
+
+    assert len(refs) == len(
+        hyps
+    ), f"Inconsistent number of reference ({len(refs)}) and hypothesis ({len(hyps)}) sequences."
+
+    ans = {
+        "ins": 0,
+        "del": 0,
+        "sub": 0,
+        "total": 0,
+        "ref_len": 0,
+    }
+    for ref, hyp in zip(refs, hyps):
+        cur = edit_distance(
+            ref, hyp, sclite_mode=sclite_mode, merge_compounds=merge_compounds
+        )
+        ans["ins"] += cur["ins"]
+        ans["del"] += cur["del"]
+        ans["sub"] += cur["sub"]
+        ans["total"] += cur["total"]
+        ans["ref_len"] += cur["ref_len"]
+
+    ans["err_rate"] = _compute_error_rate(ans["total"], ans["ref_len"])
     return ans
 
 
@@ -208,6 +260,16 @@ def _build_results(mean: float, interval: float) -> Dict[str, float]:
         "ci95min": mean - interval,
         "ci95max": mean + interval,
     }
+
+
+def _compute_error_rate(total: int, ref_len: int) -> float:
+    try:
+        return total / ref_len
+    except ZeroDivisionError:
+        if total == 0:
+            return 0.0
+        else:
+            return float("inf")
 
 
 def _convert_to_int(

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from kaldialign import align, bootstrap_wer_ci, edit_distance
+from kaldialign import align, batch_error_rate, bootstrap_wer_ci, edit_distance
 
 EPS = "*"
 
@@ -128,6 +128,70 @@ def test_edit_distance_sclite():
     }
 
 
+def test_batch_error_rate():
+    refs = [
+        ("a", "b", "c"),
+        ("d", "e"),
+    ]
+    hyps = [
+        ("a", "x", "c", "y"),
+        ("d",),
+    ]
+
+    results = batch_error_rate(refs, hyps)
+    assert results == {
+        "ins": 1,
+        "del": 1,
+        "sub": 1,
+        "total": 3,
+        "ref_len": 5,
+        "err_rate": 3 / 5,
+    }
+
+
+def test_batch_error_rate_uses_aggregate_ref_len():
+    refs = [
+        ("a",),
+        ("b", "c", "d"),
+    ]
+    hyps = [
+        ("x",),
+        ("b", "c", "d"),
+    ]
+
+    results = batch_error_rate(refs, hyps)
+    assert results["err_rate"] == 1 / 4
+
+
+def test_batch_error_rate_zero_len_ref_zero_err():
+    results = batch_error_rate([(), ()], [(), ()])
+    assert results == {
+        "ins": 0,
+        "del": 0,
+        "sub": 0,
+        "total": 0,
+        "ref_len": 0,
+        "err_rate": 0.0,
+    }
+
+
+def test_batch_error_rate_zero_len_ref_with_err():
+    results = batch_error_rate([(), ()], [(), ("a",)])
+    assert results == {
+        "ins": 1,
+        "del": 0,
+        "sub": 0,
+        "total": 1,
+        "ref_len": 0,
+        "err_rate": float("inf"),
+    }
+
+
+def test_batch_error_rate_mismatched_lengths():
+    with pytest.raises(AssertionError, match="Inconsistent number"):
+        batch_error_rate([("a",)], [("a",), ("b",)])
+
+
 approx = partial(pytest.approx, abs=3e-3)
 
 
@@ -238,6 +302,27 @@ def test_edit_distance_compound_no_false_positive():
     hyp = ["whitepaper"]
     dist = edit_distance(ref, hyp, merge_compounds=False)
     assert dist["total"] == 2  # 1 sub + 1 del
+
+
+def test_batch_error_rate_compound():
+    refs = [
+        ("white", "paper"),
+        ("hello", "world"),
+    ]
+    hyps = [
+        ("whitepaper",),
+        ("hello", "there"),
+    ]
+
+    dist = batch_error_rate(refs, hyps, merge_compounds=True)
+    assert dist == {
+        "ins": 0,
+        "del": 0,
+        "sub": 1,
+        "total": 1,
+        "ref_len": 4,
+        "err_rate": 0.25,
+    }
 
 
 def test_edit_distance_compound_sclite():


### PR DESCRIPTION
## Summary

Adds a public `batch_error_rate(refs, hyps, ...)` API that computes corpus-level error counts and error rate across a batch of reference/hypothesis sequence pairs.

The new API accumulates insertions, deletions, substitutions, total errors, and reference length across all pairs, then computes `err_rate` as `total_errors / total_ref_len`. This avoids averaging per-sequence error rates and matches standard corpus-level WER behavior.

## Impact

- Exposes a batch complement to `edit_distance()`.
- Preserves the existing zero-reference behavior: `0.0` when there are no errors, `inf` when insertions occur with zero aggregate reference length.
- Supports existing `sclite_mode` and `merge_compounds` options.
- Documents the API in the README.

## Validation

```bash
PYTHONPATH=/Users/pzelasko/code/kaldialign:/Users/pzelasko/code/kaldialign/build/lib.macosx-11.0-arm64-cpython-310 pytest tests/test_align.py
```

Result: `23 passed`.

Pre-commit hooks also passed during commit.
